### PR TITLE
Add short options which should be treated as switches.

### DIFF
--- a/fsl/wrappers/fast.py
+++ b/fsl/wrappers/fast.py
@@ -35,9 +35,16 @@ def fast(imgs, out='fast', **kwargs):
 
     valmap = {
         'nobias' : wutils.SHOW_IF_TRUE,
+        'N' : wutils.SHOW_IF_TRUE,
         'verbose' : wutils.SHOW_IF_TRUE,
+        'v' : wutils.SHOW_IF_TRUE,
         'Prior' : wutils.SHOW_IF_TRUE,
+        'P' : wutils.SHOW_IF_TRUE,
         'segments' : wutils.SHOW_IF_TRUE,
+        'g' : wutils.SHOW_IF_TRUE,
+        'b' : wutils.SHOW_IF_TRUE,
+        'B' : wutils.SHOW_IF_TRUE,
+        'p' : wutils.SHOW_IF_TRUE,
     }
 
     argmap = {


### PR DESCRIPTION
Jack had an issue with using the -B and -b options on the FAST wrapper. I thought this had worked in the past but couldn't find any evidence of this, and it looks like it's just because they're not flagged using the SHOW_IF_TRUE flag as they should.

At the same time I have added this flag for other short options that should be treated as switches. It's probably better to use the long versions of these options (which are already correctly flagged), however some people might want to directly translate their command line. -b and -B do not have long versions so need the fix in order to work properly.
